### PR TITLE
Private symbol approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # proposal-class-members
 This is a fork of the rejected js-classes-1.1 proposal aimed to pick up development where the previous proposal left off. Since the original was shot down due to the absense of a syntax for declaring public data members, that is one of the first things remedied by this fork. Along with a few syntax improvements for readability, the main goal is to provide TC39 with a proposal capable of providing everything demanded by the board without negatively impacting any features or natural integration expectations currently in the language.
 
+## Constraints
+For this proposal, and any others I may release, the following constraints are considered absolute requirements. The proposal must:
+
+* achieve the desired functionality
+* feel like regular ES code
+* be maximally compatible with all existing language features
+* be minimally conflicting with other, non-competing proposals
+* be maximally extensible for future related concepts
+* require as few trade-offs as possible
+* preserve the "prototype-based" nature of the language,
+* leave adequate room to ensure that what is sugar has a reasonably sugar-free equivalent
+
 ## Motivation
 
 This is a new proposal for extending ECMAScript's class definition syntax and semantics. It is intended to be a replacement for the  set of proposals currently under development within TC39. For the motivation behind developing a new proposal, see *[why a new proposal](docs/motivation.md)*.
@@ -16,128 +28,16 @@ The max-min class design, as implemented in ECMAScript 2015, has successfully ba
 2. **Secure method decomposition.** There should be a way for the user to refactor common code into methods that are not accessible outside of the class definition.
 3. **Customized data initialization.** There should be a way to initialize the class prototype, for instance by adding arbitrary data properties, within the class definition.
 
-## Overview
+## Mental Model
 
-This proposal borrows the concept of private symbols, as proposed [here](https://github.com/zenparsing/proposal-private-symbols), but there are a few differences. Private symbols will not be directly accessible to user-land code at all. `Object.assign` and operator `...` will not be affected by the private symbol implementation, as they only affect enumerable keys. `Object.seal` will not be affected by the private symbol implementation, as the private container is sealed immediately after initialization. `Object.freeze` will not be affected by the private symbol implementation, as it doesn't currently affect accessor properties, which remain the only "values" exposed on the object that may still change value after freezing.
+The only thing in ES that is capable of providing the 3 goals above is a closure. However, it is virtually impossible to use a closure to provide for per-instance state without the use of one or more WeakMaps. This proposal offers the concept of instance-specific closures to contain the private data. Each time a new instance is created, a new closure is created along with it and attached to all of the lexically scoped methods of the `class` definition.
 
-Many attempts to create a form of data privacy have been attempted, but all save for private-symbols have failed to create privacy in a way that preserves the functionality of Proxy in the presence of private data. However, private-symbols introduces limitations of its own. Due to the fact that private symbols are themselves 1st class values in ES, developers would have the ability to monkey-patch code containing private symbols and expose the corresponding properties to the public. This is a violation of hard private, but not one that is insurmountable. With this proposal, private symbols are a mere implementation detail that provides the ability to create properties who's name is unknown and unretrievable on any object. Using this capability, the engine will be able to hide data on an object without fear that a developer can manipulate that data through any means other than provided for in this document.
-
-
-### New products of `class`
-Both the constructor, and prototype will have additional properties as result of this proposal:
-
-#### Constructor -
-* Symbol.private("Signature") - This property contains a private symbol value used to passively perform basic brand checking. The value of this symbol is the key name for the private container created by the private initializer. This is the "class signature".
-* [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
-
-#### Prototype -
-* Symbol.private("Initializer") - This property is a function, similar to the constructor itself, and run by the constructor as the first instruction following "super". It's purpose is to create the private container on the instance and initialize the properties of that container to the specified values. The key name for this private container is the class signature. This function also creates a similar container on the constructor using the same class signature, to contain any static private data that has been declared.
-
-#### Additionally, the following property can appear on instances:
-* [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
+Just as the closure of a function provides for lexically scoped variables, the public and private members of the instance become available as lexically scope variables. It's possible for locally scoped variable to shadow these property-variables. However, the properties are always available via `obj.member` for public members and `obj::member` for private members. Equivalent array notation is also available via `obj['member']` and `obj::['member']`, respectively.
 
 
-### Instance-Private Properties
+## Links
 
-An instance-private property definition defines one or more properties that exist in one of the private containers on an instance of the class. Within a class body, instance-private properties are accessed via the `::` operator. Instance-private properties are declared with the `priv` keyword.
-
-```js
-class Point {
-  // Instance-Private property definition
-  priv x = 0;
-  priv y;
-
-  constructor(x, y) {
-    // Instance-private properties are accessed
-    // with the "::" operator
-    this::x = x;
-    this::y = y;
-  }
-}
-```
-
-Attempting to access an instance-private property using `::` produces a runtime `ReferenceError` if the class signature of the current execution context does not exist as a property of the instance object that is the left operand. In other words, a reference to an instance-private property only works when the object has been initialized by the constructor of the class owning the function making the access.
-
-Instance-private property definitions may have initializers. The absense of an initializer is equivalent to being initialized with `undefined`. The value of an instance-private property's initializer is determined at the time an instance is initialized.
-
-### Class-Private Properties
-
-The static equivalent of an instance-private property is a class-private property. Class-private properties are defined by placing the `static` keyword as the 2<sup>nd</sup> term of the definition.
-
-```js
-class A {
-  priv static field1 = Symbol('field1');
-  priv static field2;
-  ...
-}
-```
-
-Class-private properties are placed in a private container on the constructor function. Such members can be accessed via the `::` operator with the constructor function itself as the target object.
-
-### Instance-Private Methods
-
-Instance-private methods will have the same format as public methods, preceeded by `priv`. It is also possible to assign a function to a private data property. However, such functions will not be granted the class signature. It is not reasonable to expect the private initializer to be able to distinguish between initialization values that are external to the `class` definition and values defined inside the `class`. Therefore all such functions will be treated as external and left unsigned, even if they are defined inside the `class` lexical scope.
-
-```js
-class A {
-  priv member() { /* is a signed member function */ }
-  priv nonMember = () => {
-    /*
-      This one is a non-member and cannot access private members, even though
-      it is declared inside the class lexical scope. It does, however, still
-      automatically receive the `this` instance as its context.
-    */
-  }
-  priv nonMember2 = function() {
-    /*
-      This one has the same restrictions as nonMember, except that it does not
-      automatically receive the `this` instance as its context. It might as
-      have been defined outside of the `class`.
-    */
-  }
-}
-```
-
-### Public Data Properties
-
-A public data property is declared in exactly the same fashion as an instance variable, but without the `priv` prefix. Public data properties are placed on the prototype and initialized with undefined if no initializer is given, or the value of the initializer at the time the `class` definition is evaluated. Likewise, static public data properties can be created by prefixing a public data property with the `static` keyword.
-
-```js
-class A {
-  prop3 = 42;
-  static prop4;
-  ...
-}
-```
-
-### `class` Products
-
-Beyond the constructor and the prototype, the `class` keyword will, depending on the definition, produce up to 3 more products.
-* If the class contains no member definitions prefixed with `priv`, no additional products will be produced.
-* If `priv` members exist, `class` will produce at minimum a class signature applied to all functions of the class, including the constructor.
-* If there are any `priv static` members, the `class` keyword will also produce a private container on the constructor.
-* If there are any `priv` members that are not `static`:
-    * The `class` keyword will produce a private initializer function attached to the prototype.
-    * The private initializer function will produce a private container on the instance.
-
-Upon instantiation of the class, immediately following the return of the new instance from the base class, the private initializer will be executed.
-
-When a function that accesses the private members of the context object is called, the context object is cheked to see if it has a property whose name matches the class signature of that function prior to the execution of the function. The same test is performed for each access of a private member of an object that is not the current context. These 2 checks guarantee that no access to private members can be performed from an inappropriate execution context, or using an inappropriate context object. This is _brand-checking_ as defined by this proposal.
-
-### Additional Notes
-
-It is an early error if left hand argument (LHA) of a `::` operator is not an object with private members.
-
-It is an early error if the class signature of the current execution context is not a property of the LHA of the `::` operator.
-
-It is an early error if duplicate private member names are defined within a single class definition and the names do not reference a get/set accessor pair.
-
-Reflection is not externally supported for any private member. It is not a goal of this proposal to support internal reflection, but it is likewise not precluded.
-
-Private member names do not shadow public member names.
-
-### More
-
+- [Implementation Overview](docs/implementation-overview.md)
 - [Code examples](https://github.com/rdking/proposal-class-members/tree/master/examples)
 - [Definitions & Technical Notes](docs/definitions.md)
 - [Assumptions and constraints](docs/assumptions-and-constraints.md)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ This proposal borrows the concept of private symbols, as proposed [here](https:/
 ### New products of `class`
 Both the constructor, and prototype will have additional properties as result of this proposal:
 
-Constructor -
+#### Constructor -
 * Symbol.private("Signature") - This property contains a private symbol value used to passively perform basic brand checking. The value of this symbol is the key name for the private container created by the private initializer. This is the "class signature".
 * [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
 
-Prototype -
+#### Prototype -
 * Symbol.private("Initializer") - This property is a function, similar to the constructor itself, and run by the constructor as the first instruction following "super". It's purpose is to create the private container on the instance and initialize the properties of that container to the specified values. The key name for this private container is the class signature. This function also creates a similar container on the constructor using the same class signature, to contain any static private data that has been declared.
+
+#### Additionally, the following property can appear on instances:
 * [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
 
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 # proposal-class-members
 This is a fork of the rejected js-classes-1.1 proposal aimed to pick up development where the previous proposal left off. Since the original was shot down due to the absense of a syntax for declaring public data members, that is one of the first things remedied by this fork. Along with a few syntax improvements for readability, the main goal is to provide TC39 with a proposal capable of providing everything demanded by the board without negatively impacting any features or natural integration expectations currently in the language.
 
-## Constraints
-For this proposal, and any others I may release, the following constraints are considered absolute requirements. The proposal must:
-
-* achieve the desired functionality
-* feel like regular ES code
-* be maximally compatible with all existing language features
-* be minimally conflicting with other, non-competing proposals
-* be maximally extensible for future related concepts
-* require as few trade-offs as possible
-* preserve the "prototype-based" nature of the language,
-* leave adequate room to ensure that what is sugar has a reasonably sugar-free equivalent
-
 ## Motivation
 
 This is a new proposal for extending ECMAScript's class definition syntax and semantics. It is intended to be a replacement for the  set of proposals currently under development within TC39. For the motivation behind developing a new proposal, see *[why a new proposal](docs/motivation.md)*.
 
 ## Philosophy
-Elements of a `class` definition should only appear on direct products of the `class` keyword. This means that if it's not on the prototype, on the constructor, or (as of this proposal) part of the private container definition, it's not a part of the `class` definition, and therefore, not a member of the class. A class "member" is therefore anything defined or produced within the lexical scope of the `class` definition and represented in one of the products of `class`.
+
+Elements of a `class` definition should only appear on direct products of the `class` keyword. This means that if it's not on the prototype, on the constructor, or (as of this proposal) in the instance-closure, it's not a part of the `class` definition, and therefore, not a member of the class. A class "member" is therefore anything defined or produced within the lexical scope of the `class` definition and represented in or on one of the products of `class`.
 
 ## Goals
 
@@ -30,10 +19,107 @@ The max-min class design, as implemented in ECMAScript 2015, has successfully ba
 
 ## Mental Model
 
-The only thing in ES that is capable of providing the 3 goals above is a closure. However, it is virtually impossible to use a closure to provide for per-instance state without the use of one or more WeakMaps. This proposal offers the concept of instance-specific closures to contain the private data. Each time a new instance is created, a new closure is created along with it and attached to all of the lexically scoped methods of the `class` definition.
+The only thing in ES that is capable of providing the 3 goals above is a closure. However, it is virtually impossible to use a closure to provide for per-instance state without the use of one or more WeakMaps. This proposal offers an approach to applying the closure concept on class definitions to contain private data.
 
-Just as the closure of a function provides for lexically scoped variables, the public and private members of the instance become available as lexically scope variables. It's possible for locally scoped variable to shadow these property-variables. However, the properties are always available via `obj.member` for public members and `obj::member` for private members. Equivalent array notation is also available via `obj['member']` and `obj::['member']`, respectively.
+Normally, when a function returns another function defined during the run of the former, the entire execution environment of the former function is retained as a "closure" on the latter. With this proposal, a `class` definition behaves in a similar fashion to a function. Where a function closure is formed by running a function that returns 1 or more functions, an instance-closure is formed by instantiating a `class`. Likewise, a class-closure is created by evaluating a `class` definition.
 
+As a result, the member functions of the `class` instance all carry a closure associated with that instance and class. The instance-closure is associated with all non-static member functions at the time of instantiation. The class-closure is associated with all non-static member functions at the time of `class` evaluation. Unlike with normal closures, all member functions of a given `class` have access to all instance-closures of and the class-closure for the given `class`.
+
+So basically, we've been able to do this:
+```js
+function X(v) {
+  if (!new.target) throw new TypeError(`Constructor X requires new`);
+  let x = v;
+  this.print() {
+    console.log(`x = ${x}`);
+  };
+}
+```
+Now we'll be able to do this:
+```js
+class X {
+  let x;
+  constructor(v) {
+    x = v;
+  }
+  print() {
+    console.log(`x = ${v}`);
+  }
+}
+```
+...and reasonably expect that where with the `function X`:
+```js
+var a = new X(2);
+var b = new X(3);
+a.print(); //3;
+b.print(); //3;
+```
+... instead with `class X`
+```js
+var a = new X(2);
+var b = new X(3);
+a.print(); //2;
+b.print(); //3;
+```
+because each instance gets it's own closure.
+
+Just as the closure of a function provides for lexically scoped variables, the public and private members of the instance become available as lexically scope variables, as if the "with" keyword had automatically been applied at the beginning of the function. It's possible for locally scoped variable to shadow these property-variables. However, the properties are always available via `obj.member` for public members and `obj::member` for private members. Equivalent array notation is also available via `obj['member']` and `obj::['member']`, respectively.
+
+## Overview
+* To declare a private data member, use `let`.
+* To declare a constant private data member, use `const`.
+    * All constants must be initialized.
+* To declare a public data property, use `prop`.
+    * This is a prototype data property. Beware the object value foot-gun.
+* To declare a public instance data property, use `inst`.
+    * This is an instance-specific value. Beware clobbering inheritance.
+    * All public instance data properties must be initialized.
+    * It is suggested that if at all, this feature be used sparingly, and with great care.
+    * It is strongly suggested that such values be defined in the constructor.
+* All data properties can be initialized using operator `=`.
+* A new operator (`:=`) is defined for use with `inst` properties.
+    * This new operator forces the property to be defined on the instance.
+    * Use of operator `=` with `inst` attempts to set the initializer on the instance.
+* There is no unique form for defining private member functions.
+    * Private member functions are created by declaring a private data member initialized with a function defined within the lexical scope of the class.
+* The initializer of all private data members and public instance data members are resolved at the time of `class` instantiation.
+    * All other data member initializers are resolved at the time of `class` evaluation.
+* A new operator (`::`) is defined for accessing private members.
+    * If the private member's name is in a variable, you can use `obj::[variable]` to access it.
+
+#### Example
+```js
+class X {
+  let a;                  //Private data member, initialized to undefined
+  let b = {};             //Private data member, initialized to an object
+  let c = () => {};       //Private member function, bound to this
+  let d = function() {};  //Private member function, unbound
+  const e = 0;            //Private constant member, initialize to 0
+  prop f = Math.E;        //Prototype-based public data property
+  inst g = Math.PI;       //Instance-based public data property, set semantics
+  inst h := Math.random();//Instance-based public data property, define semantics
+
+  constructor(a, f) {
+    this::a = a;          //If your private member variable gets shadowed,
+    this.f = f;           //just use the property notation
+  }
+
+  copy(other) {
+    a = other::a;         //Access to members on siblings always uses property notation
+    f = other.f;
+  }
+
+  print() {               //You can iterate through private members!
+    for (let key in ['a', 'b', 'c', 'd', 'e']) {
+      console.log(`this::${key} = ${this::[key]}`);
+    }
+    //No private members in this loop at all.
+    for (let key in Object.keys(this)) {
+      console.log(`this.${key} = ${this[key]}`);
+    }
+  }
+}
+```
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@ Private member names do not shadow public member names.
 - [A refactoring example](docs/refactoring.md)
 - [Why not fields?](docs/why-not-fields.md)
 - [Specification text](https://rdking.github.io/proposal-class-members/)
+- [Private Symbols Specification](https://github.com/zenparsing/proposal-private-symbols)

--- a/docs/assumptions-and-constraints.md
+++ b/docs/assumptions-and-constraints.md
@@ -10,9 +10,24 @@ Using class-based encapsulation should be:
 - Approachable: it should look easy and fun
 - Familiar: it should be similar to other encapsulation mechanisms in Javascript
 
+## Basic Principles
+
+For this proposal, and any others I may release, the following principles are considered absolute requirements. 
+
+#### The proposal must:
+
+* achieve the desired functionality
+* feel like regular ES code
+* be maximally compatible with all existing language features
+* be minimally conflicting with other, non-competing proposals
+* be maximally extensible for future related concepts
+* require as few trade-offs as possible
+* preserve the "prototype-based" nature of the language,
+* leave adequate room to ensure that what is sugar has a reasonably sugar-free equivalent
+
 ## Constraints
 
-Our solution space is considerably limited by path-dependencies that have arisen as a result of existing practice, Babel transformations, and compile-to-JS languages.
+Our solution space is considerably limited by path-dependencies that have arisen as a result of existing practice, Babel transformations, and compile-to-JS languages. 
 
 ### C1. The current instance/class field syntax for public fields is taken
 

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1,6 +1,10 @@
 # Defintions and Technical Notes
 
-## Closure Signatures
+## Brand Checking
+- A brand check is the process by which a function verifies that it has the right to access the private container of an instance object.
+- A brand check cannot verify that the target object was constructed by the associated constructor, only that it was initialized by the constructor. 
+
+## Class Signatures
 
 - A closure signature is a unique internal value generated whenever an instance closure definition or a class closure is generated.
 - The closure signature is attached to every function and accessor declaration lexically scoped in the class definition. 

--- a/docs/implementation-overview.md
+++ b/docs/implementation-overview.md
@@ -67,12 +67,13 @@ No direct syntax support will be available for creating private member functions
 
 ## Public Data Members
 
-A public data member is declared in exactly the same fashion as a private data member, but without the `let` or `const` prefix. Public data properties are placed on the prototype and initialized with undefined if no initializer is given, or the value of the initializer at the time the `class` definition is evaluated. Likewise, static public data properties can be created by prefixing a public data property with the `static` keyword.
+A public data member is declared in almost the same fashion as a private data member, but with either `prop`, `inst`, or `static` as the prefix. Public data members declared with `prop` are placed on the prototype, while those declared with `inst` are placed on instance objects, and those declared with `static` are placed on the constructor. Members defined with either `prop` or `static` are initialized during the evaluation of the `class` definition while those defined with `inst` are initialized during the creation of an instance object. It is not valid to use `static`, `inst`, or `prop` in the same declaration as all 3 are placement modifiers targeting different objects.
 
 ```js
 class A {
-  prop3 = 42;
-  static prop4;
+  prop prop3 = 42;          //Lives on the prototype
+  static prop4;             //Lives on the constructor
+  inst prop5;               //Lives on an instance
   ...
 }
 ```
@@ -80,14 +81,14 @@ class A {
 ## `class` Products
 
 Beyond the constructor and the prototype, the `class` keyword will, depending on the definition, produce up to 3 more products.
-* If the class contains no member definitions prefixed with `priv`, no additional products will be produced.
-* If `priv` members exist, `class` will produce at minimum a class signature applied to all functions of the class, including the constructor.
-* If there are any `priv static` members, the `class` keyword will also produce a private container on the constructor.
-* If there are any `priv` members that are not `static`:
+* If the class contains no private data member definitions, no additional products will be produced.
+* If private data members exist, `class` will produce at minimum a class signature applied to all functions of the class, including the constructor.
+* If there are any class-private data members, the `class` keyword will also produce a class-closure on the constructor.
+* If there are any private data members that are not class-private:
     * The `class` keyword will produce a private initializer function attached to the prototype.
-    * The private initializer function will produce a private container on the instance.
+    * The private initializer function will produce a instance-closure on all instances.
 
-Upon instantiation of the class, immediately following the return of the new instance from the base class, the private initializer will be executed.
+Upon instantiation of the `class`, immediately following the return of the new instance from the base class, the private initializer will be executed.
 
 When a function that accesses the private members of the context object is called, the context object is cheked to see if it has a property whose name matches the class signature of that function prior to the execution of the function. The same test is performed for each access of a private member of an object that is not the current context. These 2 checks guarantee that no access to private members can be performed from an inappropriate execution context, or using an inappropriate context object. This is _brand-checking_ as defined by this proposal.
 
@@ -97,7 +98,7 @@ It is an early error if left hand argument (LHA) of a `::` operator is not an ob
 
 It is an early error if the class signature of the current execution context is not a property of the LHA of the `::` operator.
 
-It is an early error if duplicate private member names are defined within a single class definition and the names do not reference a get/set accessor pair.
+It is an early error if duplicate member names are defined within a single class definition and the names do not reference a get/set accessor pair.
 
 Reflection is not externally supported for any private member. It is not a goal of this proposal to support internal reflection, but it is likewise not precluded.
 

--- a/docs/implementation-overview.md
+++ b/docs/implementation-overview.md
@@ -1,0 +1,118 @@
+# Implementation Overview
+
+This proposal borrows the concept of private symbols, as proposed [here](https://github.com/zenparsing/proposal-private-symbols), but there are a few differences. Private symbols will not be directly accessible to user-land code at all. `Object.assign` and operator `...` will not be affected by the private symbol implementation, as they only affect enumerable keys. `Object.seal` will not be affected by the private symbol implementation, as the private container is sealed immediately after initialization. `Object.freeze` will not be affected by the private symbol implementation, as it doesn't currently affect accessor properties, which remain the only "values" exposed on the object that may still change value after freezing.
+
+Many attempts to create a form of data privacy have been attempted, but all save for private-symbols have failed to create privacy in a way that preserves the functionality of Proxy in the presence of private data. However, private-symbols introduces limitations of its own. Due to the fact that private symbols are themselves 1st class values in ES, developers would have the ability to monkey-patch code containing private symbols and expose the corresponding properties to the public. This is a violation of hard private, but not one that is insurmountable. With this proposal, private symbols are a mere implementation detail that provides the ability to create properties who's name is unknown and unretrievable on any object. Using this capability, the engine will be able to hide data on an object without fear that a developer can manipulate that data through any means other than provided for in this document.
+
+## New products of `class`
+Both the constructor, and prototype will have additional properties as result of this proposal:
+
+#### Constructor -
+* Symbol.private("Signature") - This property contains a private symbol value used to passively perform basic brand checking. The value of this symbol is the key name for the private container created by the private initializer. This is the "class signature".
+* [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
+
+#### Prototype -
+* Symbol.private("Initializer") - This property is a function, similar to the constructor itself, and run by the constructor as the first instruction following "super". It's purpose is to create the private container on the instance and initialize the properties of that container to the specified values. The key name for this private container is the class signature. This function also creates a similar container on the constructor using the same class signature, to contain any static private data that has been declared.
+
+#### Additionally, the following property can appear on instances:
+* [Constructor[Symbol.private("Signature")]] - This property contains a private container object created by the private initializer of a constructor. It holds data properties and methods that were declared private and static in the `class` definition.
+
+
+## Instance-Private Properties
+
+An instance-private property definition defines one or more properties that exist in one of the private containers on an instance of the class. Within a class body, instance-private properties are accessed via the `::` operator. Instance-private properties are declared with the `priv` keyword.
+
+```js
+class Point {
+  // Instance-Private property definition
+  priv x = 0;
+  priv y;
+
+  constructor(x, y) {
+    // Instance-private properties are accessed
+    // with the "::" operator
+    this::x = x;
+    this::y = y;
+  }
+}
+```
+
+Attempting to access an instance-private property using `::` produces a runtime `ReferenceError` if the class signature of the current execution context does not exist as a property of the instance object that is the left operand. In other words, a reference to an instance-private property only works when the object has been initialized by the constructor of the class owning the function making the access.
+
+Instance-private property definitions may have initializers. The absense of an initializer is equivalent to being initialized with `undefined`. The value of an instance-private property's initializer is determined at the time an instance is initialized.
+
+## Class-Private Properties
+
+The static equivalent of an instance-private property is a class-private property. Class-private properties are defined by placing the `static` keyword as the 2<sup>nd</sup> term of the definition.
+
+```js
+class A {
+  priv static field1 = Symbol('field1');
+  priv static field2;
+  ...
+}
+```
+
+Class-private properties are placed in a private container on the constructor function. Such members can be accessed via the `::` operator with the constructor function itself as the target object.
+
+## Instance-Private Methods
+
+Instance-private methods will have the same format as public methods, preceeded by `priv`. It is also possible to assign a function to a private data property. However, such functions will not be granted the class signature. It is not reasonable to expect the private initializer to be able to distinguish between initialization values that are external to the `class` definition and values defined inside the `class`. Therefore all such functions will be treated as external and left unsigned, even if they are defined inside the `class` lexical scope.
+
+```js
+class A {
+  priv member() { /* is a signed member function */ }
+  priv nonMember = () => {
+    /*
+      This one is a non-member and cannot access private members, even though
+      it is declared inside the class lexical scope. It does, however, still
+      automatically receive the `this` instance as its context.
+    */
+  }
+  priv nonMember2 = function() {
+    /*
+      This one has the same restrictions as nonMember, except that it does not
+      automatically receive the `this` instance as its context. It might as
+      have been defined outside of the `class`.
+    */
+  }
+}
+```
+
+## Public Data Properties
+
+A public data property is declared in exactly the same fashion as an instance variable, but without the `priv` prefix. Public data properties are placed on the prototype and initialized with undefined if no initializer is given, or the value of the initializer at the time the `class` definition is evaluated. Likewise, static public data properties can be created by prefixing a public data property with the `static` keyword.
+
+```js
+class A {
+  prop3 = 42;
+  static prop4;
+  ...
+}
+```
+
+## `class` Products
+
+Beyond the constructor and the prototype, the `class` keyword will, depending on the definition, produce up to 3 more products.
+* If the class contains no member definitions prefixed with `priv`, no additional products will be produced.
+* If `priv` members exist, `class` will produce at minimum a class signature applied to all functions of the class, including the constructor.
+* If there are any `priv static` members, the `class` keyword will also produce a private container on the constructor.
+* If there are any `priv` members that are not `static`:
+    * The `class` keyword will produce a private initializer function attached to the prototype.
+    * The private initializer function will produce a private container on the instance.
+
+Upon instantiation of the class, immediately following the return of the new instance from the base class, the private initializer will be executed.
+
+When a function that accesses the private members of the context object is called, the context object is cheked to see if it has a property whose name matches the class signature of that function prior to the execution of the function. The same test is performed for each access of a private member of an object that is not the current context. These 2 checks guarantee that no access to private members can be performed from an inappropriate execution context, or using an inappropriate context object. This is _brand-checking_ as defined by this proposal.
+
+## Additional Notes
+
+It is an early error if left hand argument (LHA) of a `::` operator is not an object with private members.
+
+It is an early error if the class signature of the current execution context is not a property of the LHA of the `::` operator.
+
+It is an early error if duplicate private member names are defined within a single class definition and the names do not reference a get/set accessor pair.
+
+Reflection is not externally supported for any private member. It is not a goal of this proposal to support internal reflection, but it is likewise not precluded.
+
+Private member names do not shadow public member names.


### PR DESCRIPTION
Updates to the documentation to use private Symbols as a means to circumvent issues with Proxy.